### PR TITLE
Final snapshot bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # EOS Snapshot Generator
 
-This tool was created to aggregate the EOS ERC20 token distribution in it's entirety, acknowledge various scenarios, run validation on data and provide files representing balances in various states. 
+This tool was created to aggregate the EOS ERC20 token distribution in it's entirety, acknowledge various scenarios, run validation on data and provide files representing balances in various states.
 
-This tool can be used to generate snapshots for **any period** in a **deterministic** fashion until the **EOS ERC20** token has been frozen. Once frozen, the tool will only produce **deterministic final** snapshots that represent the final state of the EOS ERC20 token distribution. 
+This tool can be used to generate snapshots for **any period** in a **deterministic** fashion until the **EOS ERC20** token has been frozen. Once frozen, the tool will only produce **deterministic final** snapshots that represent the final state of the EOS ERC20 token distribution.
 
 ## Table of Contents
 - [Installation](#installation)
@@ -25,9 +25,9 @@ This tool can be used to generate snapshots for **any period** in a **determinis
 
 #### Dependencies
 
-1. MySQL (local or remote) 
+1. MySQL (local or remote)
 2. Parity 1.7.8+
-3. [Node 8+](https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions) 
+3. [Node 8+](https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions)
 
 #### Time
 1. For a full sync, Parity can take 3-4 days.
@@ -39,7 +39,7 @@ _Plan accordingly_
 
 1. Ram: 16GB+ Recommended
 2. Hard drive: SSD recommended, NVME to win the race. HDD read/write speeds are intolerably slow with parity.
-3. Around 128GB of free storage, required for full parity chain, database and large file exports. 
+3. Around 128GB of free storage, required for full parity chain, database and large file exports.
 
 ### 1. Create Config File
 
@@ -47,10 +47,10 @@ _Plan accordingly_
 - **Copy** `config.default.js` and rename the copy to `config.js`. The parameters are described in the file, but for your convenience they are also listed below in greater detail. **DO NOT REMOVE OR RENAME config.default.js**
 
 ### 2. MySQL
-MySQL stores all the intricate details of the distribution and the contract. These instructions assume you already have MySQL configured locally or have a remote MySQL instance. 
+MySQL stores all the intricate details of the distribution and the contract. These instructions assume you already have MySQL configured locally or have a remote MySQL instance.
 
-- Add your mysql details to your newly copied config file. 
-- Import `schema.sql` located in the `./bin` directory of this project. 
+- Add your mysql details to your newly copied config file.
+- Import `schema.sql` located in the `./bin` directory of this project.
 
 ### 3. Start/Sync Ethereum Node
 
@@ -58,7 +58,7 @@ MySQL stores all the intricate details of the distribution and the contract. The
 
 #### Parity
 
-On most linux systems, the default IPC defined in config.default.js should work for most linux platforms. 
+On most linux systems, the default IPC defined in config.default.js should work for most linux platforms.
 
 `parity --no-warp --mode active --tracing off --pruning fast --db-compaction ssd --jsonrpc-apis all --chain mainnet --cache-size 2048`
 
@@ -68,77 +68,77 @@ If you're on Mac, it's suggested you pass a flag to parity to generate an IPC fi
 
 And then set that path in your config.js
 
-**it's imperitive that you start parity with --no-warp**. If you have a pre-existing parity configuration file you've modified, you'll want to create a new configuration file for the snapshot. 
+**it's imperitive that you start parity with --no-warp**. If you have a pre-existing parity configuration file you've modified, you'll want to create a new configuration file for the snapshot.
 **Important:** Since Parity v1.7.8 `--warp` is enabled by default. **If you fail to configure with `no-warp` you will have issues.**
 
-**Notes** 
-- If you do not use IPC, you will have limited performance due to limitations with HTTP and WS transports. 
-- If you must use an HDD, be sure to change the `--db-compaction` parameter for parity to `hdd`, like so: `--db-compaction hdd` 
-- You can adjust `--cache-size` as needed, this could provide some sync-speed improvements. 
+**Notes**
+- If you do not use IPC, you will have limited performance due to limitations with HTTP and WS transports.
+- If you must use an HDD, be sure to change the `--db-compaction` parameter for parity to `hdd`, like so: `--db-compaction hdd`
+- You can adjust `--cache-size` as needed, this could provide some sync-speed improvements.
 
 Please view [Parity Documentation](https://wiki.parity.io/Configuring-Parity) if you have issues with Parity.
 
 ### 3. Configure The Snapshot Parameters
 
-**If you're taking a "final" snapshot**, much of the configuration is automatic. 
-- A final snapshot will be taken automatically if the **crowdsale has ended** and the **tokens are frozen**, and will  override configured `period`. Block ranges for the snapshot will be determined by the opening block (first transaction from crowdsale contract) and the *deterministic freeze block*. This is to prevent user error. 
+**If you're taking a "final" snapshot**, much of the configuration is automatic.
+- A final snapshot will be taken automatically if the **crowdsale has ended** and the **tokens are frozen**, and will  override configured `period`. Block ranges for the snapshot will be determined by the opening block (first transaction from crowdsale contract) and the *deterministic freeze block*. This is to prevent user error.
 
-**If you're taking an "ongoing" snapshot,** change "period" to the period for which you would like to generate a snapshot. 
-**Note** If you put in a period that hasn't yet completed, the "last closed period" will override your choice. 
+**If you're taking an "ongoing" snapshot,** change "period" to the period for which you would like to generate a snapshot.
+**Note** If you put in a period that hasn't yet completed, the "last closed period" will override your choice.
 
 
 ### 4. Run the Snapshot
 
-From the *root directory of this project directory*, run the following: 
+From the *root directory of this project directory*, run the following:
 - `npm install` (first time)
 - `node snapshot.js --load_config`
 
 ### 5. Connections
 
-1. If MySQL and Parity are running, and Parity is synced, the script will start running. 
-2. If either MySQL or Parity are not connecting, it will keep trying every 5 seconds until a connection is established. Double-check your config and that both MySQL and Parity are running. 
-2. If Parity is not done syncing, it will tell you so, and let you know how far along it is. Once it's synced, it will continue. 
-2. If you encounter an error, see "troubleshooting" 
+1. If MySQL and Parity are running, and Parity is synced, the script will start running.
+2. If either MySQL or Parity are not connecting, it will keep trying every 5 seconds until a connection is established. Double-check your config and that both MySQL and Parity are running.
+2. If Parity is not done syncing, it will tell you so, and let you know how far along it is. Once it's synced, it will continue.
+2. If you encounter an error, see "troubleshooting"
 
 ### 6. Output
 
 #### 6a. Directory Structure
-- When complete, the script will output several files into the `./data` directory. 
-- Inside the `data` directory, will be a directory named after the period number you generated, for example: `./data/123.` If it's a final snapshot, into the `./data/final` directory. 
-- Inside that directory, is directory named after a numerical index. This is so that if you run it multiple times, you don't overwrite another snapshot. 
-- This functionality helps with verification of determinism and for development purposes. 
+- When complete, the script will output several files into the `./data` directory.
+- Inside the `data` directory, will be a directory named after the period number you generated, for example: `./data/123.` If it's a final snapshot, into the `./data/final` directory.
+- Inside that directory, is directory named after a numerical index. This is so that if you run it multiple times, you don't overwrite another snapshot.
+- This functionality helps with verification of determinism and for development purposes.
 
 #### 6b. Files
-- `snapshot.csv` - This file contains the Ethereum Address, EOS Key and EOS Balance of every address that registered correctly with the contract up to the configured period, and has a balance greater than the value set by `snapshot_minimum_balance` (default:1) 
+- `snapshot.csv` - This file contains the Ethereum Address, EOS Key and EOS Balance of every address that registered correctly with the contract up to the configured period, and has a balance greater than the value set by `snapshot_minimum_balance` (default:1)
 - `snapshot-unregistered.csv` - This file contains the Ethereum Address and EOS Balance of every address that either failed to register or registered incorrectly with the crowdsale contract up to the configured period.
-- `distribution.csv` - This file includes the Ethereum Address and EOS balance of the entire distribution up to the configured period, with no rules or validation imposed. 
+- `distribution.csv` - This file includes the Ethereum Address and EOS balance of the entire distribution up to the configured period, with no rules or validation imposed.
 - `snapshot.json` - This file contains information about the snapshot-session that created the above files. This file should not be used for verification, but can be used for debugging and to help identify indeterminism.
 
 #### 6c. Snapshot in Root Directory
-If `overwrite_snapshot` is set to true, all the above files will be put into the root directory of the project. If you are doing any development on this project, it's suggested that you change this to `false` (it's enabled by default in the `config.default.js` file.) 
+If `overwrite_snapshot` is set to true, all the above files will be put into the root directory of the project. If you are doing any development on this project, it's suggested that you change this to `false` (it's enabled by default in the `config.default.js` file.)
 
 ## Configuration Options
 
 There are three methods for configuration
 1. *Config File* (recommended)
 2. *User Prompt*, fast if your using default mysql, redis and web3 settings.
-3. *CLI* args, will override _Prompt_ 
+3. *CLI* args, will override _Prompt_
 
 ### Snapshot Parameters
 - `period` (integer, default: last closed period) The period to sync to, it will sync to the last block of any given period.
 - `snapshot_minimum_balance` (integer, default: 1) Minimum balance required for inclusion in snapshots.
-- `overwrite_snapshot`(boolean, default: true) Overwrites snapshots in root directory. 
+- `overwrite_snapshot`(boolean, default: true) Overwrites snapshots in root directory.
 
 ### Session Parameters
 - `poll` (boolean) Will finish the configured period, and then try the next one. If the next one isn't ready (or tokens aren't frozen) it will continue to try every 10 seconds until there's a new period to process.
-- `resume` (boolean) Will resume from last synced data. If you successfully run period 1, and the run period 3 with resume, it will only sync contract data between 1 and 3 (instead of starting fresh) and will only update wallets with changes between 1 and 3. **Important** This functionality isn't perfect, there are situations where this flag could produce a failed test and force a resync (run without resume) 
-- `only_produce_final_snapshot` (boolean) Should be used in conjunction with poll. It will sync contract data, but will only calculate wallets after the tokens are frozen. 
+- `resume` (boolean) Will resume from last synced data. If you successfully run period 1, and the run period 3 with resume, it will only sync contract data between 1 and 3 (instead of starting fresh) and will only update wallets with changes between 1 and 3. **Important** This functionality isn't perfect, there are situations where this flag could produce a failed test and force a resync (run without resume)
+- `only_produce_final_snapshot` (boolean) Should be used in conjunction with poll. It will sync contract data, but will only calculate wallets after the tokens are frozen.
 
 ### Misc
 - `author` (string, default: "Anonymous") Optional meta to identify snapshotter
 
-### Connection Details 
-- `eth_node_type` (http, ipc , ws) [default: http] Based on performance testing, `ipc` is recommended for local configurations and `http` is recommended for cloud configurations. 
+### Connection Details
+- `eth_node_type` (http, ipc , ws) [default: http] Based on performance testing, `ipc` is recommended for local configurations and `http` is recommended for cloud configurations.
 - `eth_node_path` (valid host/path) Relative to type as defined above
 - `mysql_db`
 - `mysql_user`
@@ -162,25 +162,25 @@ _Misuse of these parameters without understanding the implications can result in
 Because you need to sync the entire blockchain.
 
 ### Why is a database necessary?
-Because this distribution requires an ETL mechanism in order to determinstically aggregate the distribution. 
+Because this distribution requires an ETL mechanism in order to determinstically aggregate the distribution.
 
 ### What happens to tokens left unclaimed in contract?
-Unclaimed tokens are attributed to the contributing address. 
+Unclaimed tokens are attributed to the contributing address.
 
 ### What if an address sent EOS ERC20 tokens to EOSCrowdsale or EOSToken contract?
 Tokens accidentally sent to one of the contracts are attributed to the sending address.
 
 ### What happens if a wallet isn't registered?
-It is exposed to fallback registeration. Script will sync all ethereum public keys in block range. If it can locate a public key belonging to an unregsitered address, it will generate an EOS Public Key from the Ethereum Public Key. The Ethereum Private Key should then match the EOS Public Key (NOTE: This is highly experimental, but has been tested to work with high confidence) 
+It is exposed to fallback registeration. Script will sync all ethereum public keys in block range. If it can locate a public key belonging to an unregsitered address, it will generate an EOS Public Key from the Ethereum Public Key. The Ethereum Private Key **converted to EOS WIF** should then match the EOS Public Key (NOTE: This is highly experimental, but has been tested to work with high confidence)
 
 ### What happens to the unregistered supply of tokens?
-Addresses not exposed to fallback registrations that remain invalid are exported to `snapshot-unregistered.csv` file, which could prove useful. 
+Addresses not exposed to fallback registrations that remain invalid are exported to `snapshot-unregistered.csv` file, which could prove useful.
 
 ### What is determinstic index?
 Determinstic index is the order of all wallets with respect to when they were seen by either of the contract's (EOSCrowdsale and EOSTokens)
 
 ### How are account names set?
-Account names the deterministic index encoded to byte32, and then padded with "genesis11111" up to 12 chars. 
+Account names the deterministic index encoded to byte32, and then padded with "genesis11111" up to 12 chars.
 
 ### Does the script validate EOS keys?
 Yes
@@ -189,11 +189,11 @@ Yes
 Because of this [unresolved issue](https://github.com/ethereum/web3.js/issues/1610)
 
 ### What happens if EOS key does not validate?
-Registration Fallback will attempt to find a public key for the address, and fallback register it. 
+Registration Fallback will attempt to find a public key for the address, and fallback register it.
 
 ### Do I need to agree on block numbers with others for block ranges?
 
-NO! That sounds like a recipe for indeterminism. The script will choose the deterministic end block for final snapshot, it's picks that block by detecting when the tokens were frozen. For ongoing snapshots the block ranges are determined by period, from the first block where the crowdsale had a transaction, to the last block of the defined period. 
+NO! That sounds like a recipe for indeterminism. The script will choose the deterministic end block for final snapshot, it's picks that block by detecting when the tokens were frozen. For ongoing snapshots the block ranges are determined by period, from the first block where the crowdsale had a transaction, to the last block of the defined period.
 
 ## Troubleshooting
 
@@ -210,7 +210,7 @@ npm install
 
 ### I got a "block not found" error
 
-You probably started your Parity node without `--no-warp` (add --no-warp to parity startup), if using geth make sure `syncmode` is set to "full"` is set (`--syncmode "full"`_
+You probably started your Parity node without `--no-warp` (add --no-warp to parity startup), if using geth make sure `syncmode` is set to "full" (For example: `--syncmode "full"`)
 
 
 ### I'm seeing a useless error or I public keys don't appear to be syncing
@@ -228,21 +228,21 @@ npm install
 
 ### Suggested usage (sync up to last closed period and poll)
 
-`node snapshot --load_config --poll --resume --period=350` 
+`node snapshot --load_config --poll --resume --period=350`
 
 If period 350 isn't closed yet, the script will reset your period to the `last_closed_period`, and then when finished try to sync again.
 
 ### Recalculate Wallets, keep contract data (failed tests)
 
-`node snapshot --load_config --poll --resume --recalculate_wallets --period=350` 
+`node snapshot --load_config --poll --resume --recalculate_wallets --period=350`
 
-This will recalculate the wallets, but resume on the contract data. 
+This will recalculate the wallets, but resume on the contract data.
 
 ### Start from Scratch (failed tests)
 
-`node snapshot --load_config --period=350 --recalculate_wallets` 
+`node snapshot --load_config --period=350 --recalculate_wallets`
 
-This is a nuke, it will truncate your contract tables and wallet table, recalculating wallets. 
+This is a nuke, it will truncate your contract tables and wallet table, recalculating wallets.
 
 _Note: Public Keys table is not deleted, if you need to delete it for whatever reason, it must be done manually_
 
@@ -250,7 +250,7 @@ _Note: Public Keys table is not deleted, if you need to delete it for whatever r
 
 add `--verbose_mt` to startup
 
-Verbose MT will display stdout from child processes, it's noisy, so it's disabled by default. 
+Verbose MT will display stdout from child processes, it's noisy, so it's disabled by default.
 
 
 
@@ -258,16 +258,16 @@ Verbose MT will display stdout from child processes, it's noisy, so it's disable
 
 There are some differences between "ongoing" and "final" snapshots that need to be mentioned.
 
-- *Ongoing* snapshots will produce accurate output based on period by constraining all blockchain activity to that range. 
-   - Block range for each period must be found (determinism) 
-   	- Block range is defined by period, first block of crowdsale to the last block of the defined period. 
+- *Ongoing* snapshots will produce accurate output based on period by constraining all blockchain activity to that range.
+   - Block range for each period must be found (determinism)
+   	- Block range is defined by period, first block of crowdsale to the last block of the defined period.
 	- Balances are calculated cumulatively, as opposed to `balanceOf()` method provided by  EOSCrowdsale contract
-	- EOS Key Registration is concluded by last registration within the block range. 
-- *Final* simplifies a few things. 
+	- EOS Key Registration is concluded by last registration within the block range.
+- *Final* simplifies a few things.
 	- Block range is defined by the first block of crowdsale (when first transaction occured) to the freeze block
 	- Balances are not calculated but inferred from state returned by `balanceOf()` function provided by Token Contract.
-	- EOS Key Registration is concluded by last registration within the block range. (keys public constant provided by EOSCrowdsale contract is not used) 
-	
+	- EOS Key Registration utilizes `key()` public constant from crowdsale contract, registrations are not possible after 23 hours after distribution finishes.
+
 
 ## How It Works
 #### High Level
@@ -275,14 +275,14 @@ There are some differences between "ongoing" and "final" snapshots that need to 
 The snapshot parameters this software proposes are as follows
 
 1. All data is constrained by block range determined by period (for ongoing snapshots)
-1. EOS Balance of an address must be greater-than or equal to `snapshot_minimum_balance` to be considered valid for snapshot export. 
+1. EOS Balance of an address must be greater-than or equal to `snapshot_minimum_balance` to be considered valid for snapshot export.
 2. An EOS key must be associated to an account either by registration
-3. If an ethereum address sent EOS ERC20 tokens to the EOS Crowdsale or EOS Token contract within the block range of the snapshot, these tokens are allocated to the respective address. 
+3. If an ethereum address sent EOS ERC20 tokens to the EOS Crowdsale or EOS Token contract within the block range of the snapshot, these tokens are allocated to the respective address.
 4. If an address has unclaimed EOS ERC20 tokens in the EOS Crowdsale contract within block range, these tokens are allocated to the respective address.
-5. If an address is unregistered and the script was able to find a public key belonging to the address, it will generate an EOS Public Key that matches the holding addresses' Ethereum private key. 
-5. Registered addresses whose EOS key validates and whose EOS ERC20 balance is greater-than or equal to the `minimum_snapshot_balance` are exported to `snapshot.csv` file (ethereum address, EOS public key, balance) 
-5. Addresses that are not registered but are equal to or greater-than the `minimum_snapshot_balance`, will be exported to `snapshot_unregistered.csv` (ethereum address, balance) 
-6. Entire distribution is exported to `distribution.csv` file without any rules or validation applied (ethereum address, balance) 
+5. If an address is unregistered and the script was able to find a public key belonging to the address, it will generate an EOS Public Key that matches the holding addresses' Ethereum private key.
+5. Registered addresses whose EOS key validates and whose EOS ERC20 balance is greater-than or equal to the `minimum_snapshot_balance` are exported to `snapshot.csv` file (ethereum address, EOS public key, balance)
+5. Addresses that are not registered but are equal to or greater-than the `minimum_snapshot_balance`, will be exported to `snapshot_unregistered.csv` (ethereum address, balance)
+6. Entire distribution is exported to `distribution.csv` file without any rules or validation applied (ethereum address, balance)
 
 
 <a name="snapshot-install-manual-about-lowlevel"></a>
@@ -292,7 +292,7 @@ The script employs strict patterns to encourage predictable output, often at the
 
 Below is the script transposed to plain english.
 
-1. User Configured Parameters are set through one of three methods. 
+1. User Configured Parameters are set through one of three methods.
 2. Check Connections to MySQL, Redis and Web3
 3. Truncate Databases
 4. Generate Period Map
@@ -300,20 +300,20 @@ Below is the script transposed to plain english.
 	2. Determines the block range that the snapshot is based upon
 5. Set Application State Variables (including user configurations)
 6. Set Block Range
-	7. If tokens are frozen, force the snapshot block range to `state.block_state` and the deterministic freeze block (block tokens were frozen) 
-	8. Otherwise, set block range to user defined block range. 
+	7. If tokens are frozen, force the snapshot block range to `state.block_state` and the deterministic freeze block (block tokens were frozen)
+	8. Otherwise, set block range to user defined block range.
 6. Sync Public keys
-	7. For every address between block range, sync ethereum public keys to table. 
+	7. For every address between block range, sync ethereum public keys to table.
 	8. If IPC connection, use multi-threaded implementation.
-5. Sync history of token and crowdsale contract. 
+5. Sync history of token and crowdsale contract.
 	1. EOS Transfers
 	2. Buys
 	3. Claims
 	4. Registrations
 	5. Reclaimable Transfers
-	6. Resuming: 
+	6. Resuming:
 		6. If resume is set, it will only sync data from where it left off
-		7. Otherwise, contract tables will be truncated and it will re-sync everything from scratch. 
+		7. Otherwise, contract tables will be truncated and it will re-sync everything from scratch.
 2. Compile list of every address that has ever had an EOS balance, for each address:
 	1. Aggregate relevant txs
 		1. Claims and Buys, required for Unclaimed Balance Calculation
@@ -335,27 +335,27 @@ Below is the script transposed to plain english.
 		6. Save every wallet regardless of validation or balance to `wallets` table
         6. Resuming:
 	        7. resume is set and recalculate_wallets is not set, it will only process the above data for addresses with changes since the last sync and adjust block range for wallets accordingly (in the case of buys, it will aggregate based on period not on block range, because future buys are possible)
-		8. resume is not set or recalculate_wallets is set, it will truncate wallets table and process all addresses. 
+		8. resume is not set or recalculate_wallets is set, it will truncate wallets table and process all addresses.
 1. Registration Fallback
 	1. Query invalid addresses, above minimum snapshot threshold and without register error "exclude" (EOSToken/Crowdsale contracts)
 	2. Attempt to locate public key for each addrses
-		1. if a public key is found, convert it to an EOS Key, update the wallet with the generated key, set fallback to true and set valid to true. 
+		1. if a public key is found, convert it to an EOS Key, update the wallet with the generated key, set fallback to true and set valid to true.
 2. Deterministic Index and Account Names
 	3. 	Query addresses `order by first_seen, address` in batches of 10000.
 	4. For each batch set the deterministic index and generate the account name
 	5. Update each address.
 3. Test
-	1. Daily Totals from DB against daily totals from EOS Utility Contract, failure here would not fail the below tests, but would instead result in inaccurate unclaimed balances. Difficult problem to detect without this test. 
+	1. Daily Totals from DB against daily totals from EOS Utility Contract, failure here would not fail the below tests, but would instead result in inaccurate unclaimed balances. Difficult problem to detect without this test.
 	2. Total Supply, margin of error should be low due to _dust_ from rounding (generally 0.00000001%)
    3. Negative Balances, there should be **zero** negative balances
 7. Output
-	1. **snapshot.csv** - comma-delimited list of ETH addresses, EOS keys and Total EOS ERC20 Balances (user, key, balance respectively) 
-		1. Move all valid entries from `wallets` table to `snapshot` table, ordered by balance DESC. 
+	1. **snapshot.csv** - comma-delimited list of ETH addresses, EOS keys and Total EOS ERC20 Balances (user, key, balance respectively)
+		1. Move all valid entries from `wallets` table to `snapshot` table, ordered by balance DESC.
 		2. Generate snapshot.csv from `snapshot` table
 	1. **snapshot_unregistered.csv** - comma-delimited list of ETH addresses and Total EOS ERC20 Balances (user, balance respectively)
 		1. Move all invalid entries whose balance is greater-than or equal-to `minimum_snapshot_balance` from `wallets` table to `snapshot_unregistered` table, ordered by balance DESC.
 		2. Generate snapshot_unregistered.csv from `snapshot_unregistered` table
-	1. **distribution.csv** - comma-delimited list of ETH addresses and Total EOS ERC20 Balances (user, balance respectively) **does not include EOS keys!** 
+	1. **distribution.csv** - comma-delimited list of ETH addresses and Total EOS ERC20 Balances (user, balance respectively) **does not include EOS keys!**
 		1. Export all Ethereum Addresses and EOS ERC20 total balances from `wallets` table without any rules of validation imposed to **distribution.csv**
    2. **snapshot.json** - Snapshot meta data
 
@@ -365,7 +365,7 @@ Below is the script transposed to plain english.
 		4. Generate MD5 Checksums
 			1. 	From generated **snapshot.csv** file, useful for debugging and auditing
 			2. From mysql checksum for every table in database (useful for debugging)
-		5. Pass any other useful state variables into object 
+		5. Pass any other useful state variables into object
 
 
 
@@ -374,12 +374,12 @@ Below is the script transposed to plain english.
 - **wallet balance** - The wallet balance is refers to an address's EOS ERC20 token balance
 - **unclaimed balance** - An unclaimed balance refers to tokens that were never claimed by an address. Despite being unclaimed, these still belong to the contributing address.
 - **reclaimed balance** - A reclaimed balance refers to EOS ERC20 tokens accidentally sent to the EOSCrowdsale or EOSToken contract. The balances of these contracts are not included in distribution calculations, so it's imperitive these balances are calculated to have accurate supply values.  
-- **total balance** - The sum of **wallet** + **unclaimed** + **reclaimed** balances. The total balance is what is included as a user's balance in snapshots. 
+- **total balance** - The sum of **wallet** + **unclaimed** + **reclaimed** balances. The total balance is what is included as a user's balance in snapshots.
 - **registered address** - A registered address is an address with a balance greater than or equal to the `minimum_snapshot_balance` that has correctly registered their ethereum address with the EOSCrowdsale contract using a valid EOS Public Key.
 - **unregistered address** - An unregistered address is an address with a balance greater than or equal to the - `minimum_snapshot_balance` that has either incorrectly registered  or failed to register their address with an EOS Public Key.
-- **freeze block** - The freeze block is a deterministic value represented by the block number representing the period that tokens were frozen. This block will mark the last block for which actions sent to the crowdsale contract will be honored (such as registrations) 
+- **freeze block** - The freeze block is a deterministic value represented by the block number representing the period that tokens were frozen. This block will mark the last block for which actions sent to the crowdsale contract will be honored (such as registrations)
 - **snapshot** - A file containing EOS public keys and balances that can be imported during an EOSIO boot sequence.
 - **snapshot-unregistered** - A file containing Ethereum addressees and balances. This file could potentially be imported during an EOSIO boot sequence into the table of a contract that enables Ethereum based claiming.
 - **liquid supply** - The liquid supply represents total aggregate EOS ERC20 tokens that are presently in circulation and detected by snapshot script, after the crowdsale ends, the liquid supply should equal the total supply.
 - **expected supply** - Expected supply is a mathematically determined value representing what the script expects the liquid supply to equal. Liquid Supply should be within 0.00000001% of expected supply as a result of dust acquired by precision reduction.
-- **registration fallback** - Registering an EOS Public Key for an unregistered address utilizing a discovered public key. 
+- **registration fallback** - Registering an EOS Public Key for an unregistered address utilizing a discovered public key.

--- a/tools/snapshot/classes/Wallet.Final.js
+++ b/tools/snapshot/classes/Wallet.Final.js
@@ -1,13 +1,22 @@
 const async  = require('async'),
       bn     = require('bignumber.js'),
       Wallet = require('./Wallet'),
-      util = require('../utilities')
+      util = require('../utilities'),
+      address_key = require('../helpers/web3-address').key
 
 class WalletFinal extends Wallet {
 
   process_key( complete ){
-    this.maybe_fix_key()
-    complete()
+    address_key( this.address )
+      .then( key => {
+        //encode because some of register function exploits ... fixes a different problem from the web3 fork problem
+        this.eos_key = encodeURIComponent(key)
+        this.maybe_fix_key()
+        complete()
+      })
+      .catch( e => {
+        throw new Error(e)
+      })
   }
 
   process_balance_wallet( complete ){

--- a/tools/snapshot/classes/Wallet.Final.js
+++ b/tools/snapshot/classes/Wallet.Final.js
@@ -10,7 +10,7 @@ class WalletFinal extends Wallet {
     address_key( this.address )
       .then( key => {
         //encode because some of register function exploits ... fixes a different problem from the web3 fork problem
-        this.eos_key = encodeURIComponent(key)
+        this.eos_key = util.misc.clean_user_input(key)
         this.maybe_fix_key()
         complete()
       })

--- a/tools/snapshot/classes/Wallet.Final.js
+++ b/tools/snapshot/classes/Wallet.Final.js
@@ -10,7 +10,7 @@ class WalletFinal extends Wallet {
     address_key( this.address )
       .then( key => {
         //encode because some of register function exploits ... fixes a different problem from the web3 fork problem
-        this.eos_key = util.misc.clean_user_input(key)
+        this.eos_key = util.misc.sanitize_user_input(key)
         this.maybe_fix_key()
         complete()
       })

--- a/tools/snapshot/helpers/web3-address.js
+++ b/tools/snapshot/helpers/web3-address.js
@@ -30,4 +30,4 @@ address.key = address => {
     .keys( address ).call()
 }
 
-module.exports = user
+module.exports = address

--- a/tools/snapshot/index.js
+++ b/tools/snapshot/index.js
@@ -80,8 +80,6 @@ module.exports = (COMPLETE) => {
       throw new Error(error)
     }
     else {
-      console.log(art("complete","2"))
-      console.log(`Snapshot for Period #${config.period} Completed.`)
     }
 
     // const sync_progress_destroy = require('./queries').sync_progress_destroy
@@ -109,8 +107,8 @@ module.exports = (COMPLETE) => {
     //In polling, the config.period is autoincremented before check_for_poll() is called,
     //so if it's greater than the highest period index (350) and the last closed period eq highest period index
     //Check if the token is frozen before attempting to generate final snapshot (tasks/block_range.js will force run the final snapshot.)
-    else if(period.last_closed == CS_MAX_PERIOD_INDEX && config.period > CS_MAX_PERIOD_INDEX) {
-      contract = require('../../helpers/web3-contract.js')
+    else if(period.last_closed() == CS_MAX_PERIOD_INDEX) {
+      contract = require('./helpers/web3-contract.js')
       contract.$token.methods.stopped().call()
         .then( stopped => {
           if(stopped) {
@@ -178,12 +176,11 @@ module.exports = (COMPLETE) => {
       else if(config.period > period.last_closed()) {
         let cache_period = config.period
         config.period = period.last_closed()
-        console.log(colors.italic.red(`It appears you've set your period to ${cache_period}, has not completed yet. Period has been reset to ${config.period}`))
-      }
-      else if(config.period > CS_MAX_PERIOD_INDEX) {
-        let cache_period = config.period
-        config.period = CS_MAX_PERIOD_INDEX
-        console.log(colors.italic.red(`It appears you've set your period to ${cache_period}, which doesn't exist. Period has been reset to ${config.period}`))
+        if(config.period < 0)
+          console.log(colors.bold.red(`Period 0 hasn't even finished yet, exiting. try again later`)),
+          process.exit()
+        else
+          console.log(colors.italic.red(`It appears you've set your period to ${cache_period}, has not completed yet. Period has been reset to ${config.period}`))
       }
 
       next(null, config)

--- a/tools/snapshot/index.js
+++ b/tools/snapshot/index.js
@@ -80,6 +80,15 @@ module.exports = (COMPLETE) => {
       throw new Error(error)
     }
     else {
+      if(state.mode == "final") {
+        console.log(art("final snapshot complete","2"))
+        process.exit()
+        return
+      }
+      else {
+        console.log(art("complete","2"))
+        console.log(`Snapshot for Period #${config.period} Completed.`)
+      }
     }
 
     // const sync_progress_destroy = require('./queries').sync_progress_destroy

--- a/tools/snapshot/tasks/export/snapshot-unregistered.csv.js
+++ b/tools/snapshot/tasks/export/snapshot-unregistered.csv.js
@@ -34,7 +34,7 @@ module.exports = ( state, callback ) => {
     .destroy({ truncate : true, cascade: false })
     .then( () => {
       db.sequelize
-        .query(`INSERT INTO snapshot_unregistered (id, user, account_name, balance) SELECT deterministic_index, address, account_name, balance_total FROM wallets WHERE valid=0 AND register_error!='exclude' AND balance_total>=${config.snapshot_minimum_balance} ORDER BY deterministic_index, address ASC`)
+        .query(`INSERT INTO snapshot_unregistered (id, user, account_name, balance) SELECT deterministic_index, address, account_name, balance_total FROM wallets WHERE valid=0 AND register_error!='exclude' AND balance_total>=${config.snapshot_minimum_balance} ORDER BY deterministic_index ASC, address ASC`)
         .then(results => {
           console.log( 'Unregistered Snapshot Table Synced' )
           csv( callback )

--- a/tools/snapshot/tasks/process/wallets.js
+++ b/tools/snapshot/tasks/process/wallets.js
@@ -48,7 +48,6 @@ module.exports = (state, complete) => {
   /**
   * Instantiates the wallet and passes into the control flow.
   * @param {object} wallet Cumulative object passed through waterfall control_flow
-  * @param {boolean} finished Waterfall control_flow callback, passes (error, subject), subject is passed to next function in control flow
   * @param {function} finished Waterfall control_flow callback, passes (error, subject), subject is passed to next function in control flow
   */
   const init = (address, finished) => {
@@ -59,7 +58,6 @@ module.exports = (state, complete) => {
   /**
   * Queries the most recent register within the block range and saves it to wallet. This is required for determinism, "keys" constant function cannot be used here.
   * @param {object} wallet Cumulative object passed through waterfall control_flow
-  * @param {boolean} finished Waterfall control_flow callback, passes (error, subject), subject is passed to next function in control flow
   * @param {function} finished Waterfall control_flow callback, passes (error, subject), subject is passed to next function in control flow
   */
   const key = (wallet, finished) => {
@@ -77,7 +75,6 @@ module.exports = (state, complete) => {
   /**
   * If mode is ongoing, queries incoming/outgoing transfers separately, and saves them to wallet for later processing by utility.balance.transfersCumulative
   * @param {object} wallet Cumulative object passed through waterfall control_flow
-  * @param {boolean} finished Waterfall control_flow callback, passes (error, subject), subject is passed to next function in control flow
   * @param {function} finished Waterfall control_flow callback, passes (error, subject), subject is passed to next function in control flow
   */
   const transfers = (wallet, finished) => {
@@ -140,7 +137,6 @@ module.exports = (state, complete) => {
   /**
   * Queries claims where true to an array filled with "false" by period.
   * @param {object} wallet Cumulative object passed through waterfall control_flow
-  * @param {boolean} finished Waterfall control_flow callback, passes (error, subject), subject is passed to next function in control flow
   * @param {function} finished Waterfall control_flow callback, passes (error, subject), subject is passed to next function in control flow
   */
   const claims = (wallet, finished) => {

--- a/tools/snapshot/tasks/process/wallets.js
+++ b/tools/snapshot/tasks/process/wallets.js
@@ -49,6 +49,7 @@ module.exports = (state, complete) => {
   * Instantiates the wallet and passes into the control flow.
   * @param {object} wallet Cumulative object passed through waterfall control_flow
   * @param {boolean} finished Waterfall control_flow callback, passes (error, subject), subject is passed to next function in control flow
+  * @param {function} finished Waterfall control_flow callback, passes (error, subject), subject is passed to next function in control flow
   */
   const init = (address, finished) => {
     let wallet = new Wallet( address, config )
@@ -59,6 +60,7 @@ module.exports = (state, complete) => {
   * Queries the most recent register within the block range and saves it to wallet. This is required for determinism, "keys" constant function cannot be used here.
   * @param {object} wallet Cumulative object passed through waterfall control_flow
   * @param {boolean} finished Waterfall control_flow callback, passes (error, subject), subject is passed to next function in control flow
+  * @param {function} finished Waterfall control_flow callback, passes (error, subject), subject is passed to next function in control flow
   */
   const key = (wallet, finished) => {
     query.last_register(wallet.address, state.block_begin, state.block_end, eos_key => {
@@ -71,6 +73,7 @@ module.exports = (state, complete) => {
   * If mode is ongoing, queries incoming/outgoing transfers separately, and saves them to wallet for later processing by utility.balance.transfersCumulative
   * @param {object} wallet Cumulative object passed through waterfall control_flow
   * @param {boolean} finished Waterfall control_flow callback, passes (error, subject), subject is passed to next function in control flow
+  * @param {function} finished Waterfall control_flow callback, passes (error, subject), subject is passed to next function in control flow
   */
   const transfers = (wallet, finished) => {
     //Cumulative balance calculations are not required for final snapshot because tokens will be frozen, final snapshot uses tokenContract.balanceOf()
@@ -133,6 +136,7 @@ module.exports = (state, complete) => {
   * Queries claims where true to an array filled with "false" by period.
   * @param {object} wallet Cumulative object passed through waterfall control_flow
   * @param {boolean} finished Waterfall control_flow callback, passes (error, subject), subject is passed to next function in control flow
+  * @param {function} finished Waterfall control_flow callback, passes (error, subject), subject is passed to next function in control flow
   */
   const claims = (wallet, finished) => {
     // console.log('Wallet Claims')
@@ -150,6 +154,7 @@ module.exports = (state, complete) => {
   * Queries buys belonging to address, cumulative sums multiple reclaimables belonging to a single address and maps them in a format consumable by utility.balance.unclaimed
   * @param {object} wallet Cumulative object passed through waterfall control_flow
   * @param {boolean} finished Waterfall control_flow callback, passes (error, subject), subject is passed to next function in control flow
+  * @param {function} finished Waterfall control_flow callback, passes (error, subject), subject is passed to next function in control flow
   */
   const buys = ( wallet, finished ) => {
     query.address_buys(wallet.address, state.block_begin, state.block_end, config.period)
@@ -166,6 +171,7 @@ module.exports = (state, complete) => {
   * Queries reclaimables belonging to address, and maps them in a format consumable by utility.balance.reclaimables
   * @param {object} wallet Cumulative object passed through waterfall control_flow
   * @param {boolean} finished Waterfall control_flow callback, passes (error, subject), subject is passed to next function in control flow
+  * @param {function} finished Waterfall control_flow callback, passes (error, subject), subject is passed to next function in control flow
   */
   const reclaimables = ( wallet, finished ) => {
     query.address_reclaimables( wallet.address, state.block_begin, state.block_end )
@@ -181,6 +187,7 @@ module.exports = (state, complete) => {
   * Invokes query to find first block seen, used for deterministic index, and saves lowest block to wallet object as first_seen
   * @param {object} wallet Cumulative object passed through waterfall control_flow
   * @param {boolean} finished Waterfall control_flow callback, passes (error, subject), subject is passed to next function in control flow
+  * @param {function} finished Waterfall control_flow callback, passes (error, subject), subject is passed to next function in control flow
   */
   const first_seen = ( wallet, finished ) => {
     query.address_first_seen( wallet.address )
@@ -195,6 +202,7 @@ module.exports = (state, complete) => {
   * Checks query cache for bulkCreate and invokes bulk upsert if conditional is true, invoking control_flow callback onComplete or invokes control_flow callback
   * @param {object} wallet Cumulative object passed through waterfall control_flow
   * @param {boolean} finished Waterfall control_flow callback, passes (error, subject), subject is passed to next function in control flow
+  * @param {function} finished Waterfall control_flow callback, passes (error, subject), subject is passed to next function in control flow
   */
   const processing = ( wallet, finished ) => {
     wallet.process( json => {
@@ -208,6 +216,7 @@ module.exports = (state, complete) => {
   * Checks query cache for bulkCreate and invokes bulk upsert if conditional is true, invoking control_flow callback onComplete or invokes control_flow callback
   * @param {function} next_address eachSeries control_flow callback
   * @param {boolean} is_complete Override used to force upsert the cache.
+  * @param {function} is_complete Override used to force upsert the cache.
   */
   const save_or_continue = (next_address, is_complete = false) => {
     if(cache.length >= 50 || is_complete || cache.length == state.total )

--- a/tools/snapshot/tasks/process/wallets.js
+++ b/tools/snapshot/tasks/process/wallets.js
@@ -63,6 +63,11 @@ module.exports = (state, complete) => {
   * @param {function} finished Waterfall control_flow callback, passes (error, subject), subject is passed to next function in control flow
   */
   const key = (wallet, finished) => {
+    if(state.mode == "final")  {
+      //use EOSCrowdsale.keys()
+      finished( null, wallet )
+      return
+    }
     query.last_register(wallet.address, state.block_begin, state.block_end, eos_key => {
       wallet.eos_key = eos_key
       finished( null, wallet )

--- a/tools/snapshot/tasks/process/wallets.js
+++ b/tools/snapshot/tasks/process/wallets.js
@@ -153,7 +153,6 @@ module.exports = (state, complete) => {
   /**
   * Queries buys belonging to address, cumulative sums multiple reclaimables belonging to a single address and maps them in a format consumable by utility.balance.unclaimed
   * @param {object} wallet Cumulative object passed through waterfall control_flow
-  * @param {boolean} finished Waterfall control_flow callback, passes (error, subject), subject is passed to next function in control flow
   * @param {function} finished Waterfall control_flow callback, passes (error, subject), subject is passed to next function in control flow
   */
   const buys = ( wallet, finished ) => {
@@ -170,7 +169,6 @@ module.exports = (state, complete) => {
   /**
   * Queries reclaimables belonging to address, and maps them in a format consumable by utility.balance.reclaimables
   * @param {object} wallet Cumulative object passed through waterfall control_flow
-  * @param {boolean} finished Waterfall control_flow callback, passes (error, subject), subject is passed to next function in control flow
   * @param {function} finished Waterfall control_flow callback, passes (error, subject), subject is passed to next function in control flow
   */
   const reclaimables = ( wallet, finished ) => {
@@ -186,7 +184,6 @@ module.exports = (state, complete) => {
   /**
   * Invokes query to find first block seen, used for deterministic index, and saves lowest block to wallet object as first_seen
   * @param {object} wallet Cumulative object passed through waterfall control_flow
-  * @param {boolean} finished Waterfall control_flow callback, passes (error, subject), subject is passed to next function in control flow
   * @param {function} finished Waterfall control_flow callback, passes (error, subject), subject is passed to next function in control flow
   */
   const first_seen = ( wallet, finished ) => {
@@ -201,7 +198,6 @@ module.exports = (state, complete) => {
   /**
   * Checks query cache for bulkCreate and invokes bulk upsert if conditional is true, invoking control_flow callback onComplete or invokes control_flow callback
   * @param {object} wallet Cumulative object passed through waterfall control_flow
-  * @param {boolean} finished Waterfall control_flow callback, passes (error, subject), subject is passed to next function in control flow
   * @param {function} finished Waterfall control_flow callback, passes (error, subject), subject is passed to next function in control flow
   */
   const processing = ( wallet, finished ) => {
@@ -215,7 +211,6 @@ module.exports = (state, complete) => {
   /**
   * Checks query cache for bulkCreate and invokes bulk upsert if conditional is true, invoking control_flow callback onComplete or invokes control_flow callback
   * @param {function} next_address eachSeries control_flow callback
-  * @param {boolean} is_complete Override used to force upsert the cache.
   * @param {function} is_complete Override used to force upsert the cache.
   */
   const save_or_continue = (next_address, is_complete = false) => {

--- a/tools/snapshot/tasks/sync/contract.js
+++ b/tools/snapshot/tasks/sync/contract.js
@@ -120,6 +120,7 @@ module.exports = ( state, complete ) => {
               position:     registration.transactionIndex,
               block_number: registration.blockNumber,
               address:      registration.returnValues.user.toLowerCase(),
+              //encode because some of register function exploits ... fixes a different problem from the web3 fork problem
               eos_key:      encodeURIComponent(registration.returnValues.key)
             }
           })

--- a/tools/snapshot/tasks/sync/contract.js
+++ b/tools/snapshot/tasks/sync/contract.js
@@ -121,7 +121,7 @@ module.exports = ( state, complete ) => {
               block_number: registration.blockNumber,
               address:      registration.returnValues.user.toLowerCase(),
               //encode because some of register function exploits ... fixes a different problem from the web3 fork problem
-              eos_key:      util.misc.clean_user_input(registration.returnValues.key)
+              eos_key:      util.misc.sanitize_user_input(registration.returnValues.key)
             }
           })
           state.sync_contract.registrations+=request.length

--- a/tools/snapshot/tasks/sync/contract.js
+++ b/tools/snapshot/tasks/sync/contract.js
@@ -121,7 +121,7 @@ module.exports = ( state, complete ) => {
               block_number: registration.blockNumber,
               address:      registration.returnValues.user.toLowerCase(),
               //encode because some of register function exploits ... fixes a different problem from the web3 fork problem
-              eos_key:      encodeURIComponent(registration.returnValues.key)
+              eos_key:      util.misc.clean_user_input(registration.returnValues.key)
             }
           })
           state.sync_contract.registrations+=request.length

--- a/tools/snapshot/utilities/misc.js
+++ b/tools/snapshot/utilities/misc.js
@@ -62,6 +62,10 @@ const convert_ethpk_to_eospk = ( pubkey ) => {
   return eoskey
 }
 
+const clean_user_input = ( input ) => {
+  return encodeURIComponent(input.replace(/[^0-z]+/g, "").replace(/[^\x20-\x7E]+/g, ''))
+}
+
 module.exports = {
   iota: iota,
   hex_to_ascii: hex_to_ascii,
@@ -73,5 +77,6 @@ module.exports = {
   tx_hash_from_query_results: tx_hash_from_query_results,
   pubkey_from_tx_hash: pubkey_from_tx_hash,
   convert_ethpk_to_eospk: convert_ethpk_to_eospk,
-  address_is_contract: address_is_contract
+  address_is_contract: address_is_contract,
+  clean_user_input : clean_user_input
 }

--- a/tools/snapshot/utilities/misc.js
+++ b/tools/snapshot/utilities/misc.js
@@ -62,7 +62,7 @@ const convert_ethpk_to_eospk = ( pubkey ) => {
   return eoskey
 }
 
-const clean_user_input = ( input ) => {
+const sanitize_user_input = ( input ) => {
   return encodeURIComponent(input.replace(/[^0-z]+/g, "").replace(/[^\x20-\x7E]+/g, ''))
 }
 
@@ -78,5 +78,5 @@ module.exports = {
   pubkey_from_tx_hash: pubkey_from_tx_hash,
   convert_ethpk_to_eospk: convert_ethpk_to_eospk,
   address_is_contract: address_is_contract,
-  clean_user_input : clean_user_input
+  sanitize_user_input : sanitize_user_input
 }

--- a/tools/snapshot/utilities/periods.js
+++ b/tools/snapshot/utilities/periods.js
@@ -9,7 +9,7 @@ const changed = (compare_period) => {
 }
 
 const from_date = timestamp  => {
-  return timestamp < CS_START_TIME ? 0 : Math.min(Math.floor((timestamp - CS_START_TIME) / CS_PERIOD_LENGTH_SECONDS ) + 1, CS_MAX_PERIOD_INDEX)
+  return timestamp < CS_START_TIME ? 0 : Math.min(Math.floor((timestamp - CS_START_TIME) / CS_PERIOD_LENGTH_SECONDS ) + 1, CS_NUMBER_OF_PERIODS)
 }
 
 //TODO: Deprecate


### PR DESCRIPTION
- Final snapshot utilizes `keys()` public constant in contract. Brain fart. 
- Fix one of the web3 helpers that apparently was not even being used (relic from 10 months ago)
- Prevent continuation of polling after final snapshot. 
- **Critical Bug** Fixed detection of 350/final
- Necessary condition for testing on testnet (could prove useful!) 
- Explicitly set unregistered snapshot to order by deterministic_index ascending.
- Fixed some inline docs.
- Added some developer notes
- **Critical Bug** Fixed bug where period last closed would never == 350, causing issues with polling. 
- Updated readme to reflect changes
- Adds more extensive sanitization to user input `register()`